### PR TITLE
Simplify event driven loading

### DIFF
--- a/src/UETools.Core/DataSegment.cs
+++ b/src/UETools.Core/DataSegment.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace UETools.Core
+{
+    public sealed class DataSegment : IDisposable
+    {
+        public DataSegment(IMemoryOwner<byte> data) : this(data, 0) { }
+        private DataSegment(IMemoryOwner<byte> data, long runningIndex)
+        {
+            MemoryOwner = data;
+            RunningIndex = runningIndex;
+        }
+        internal DataSegment(Memory<byte> data) : this(new NotOwnedOwner(data)) { }
+
+        public IMemoryOwner<byte> MemoryOwner { get; }
+        public long RunningIndex { get; private set; }
+        public long Length => RunningIndex + MemoryOwner.Memory.Length;
+        internal DataSegment? NextElement { get; private set; }
+
+        public DataSegment Append(IMemoryOwner<byte> next) => NextElement is not null
+                ? throw new InvalidOperationException("Can't append to segment already containing next element.")
+                : (NextElement = new DataSegment(next, Length));
+        public DataSegment Append(IEnumerable<IMemoryOwner<byte>> elements)
+        {
+            var segment = this;
+            var enumerator = elements.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var it = enumerator.Current;
+                segment = segment.Append(it);
+            }
+            return segment;
+        }
+
+        public void Dispose()
+        {
+            MemoryOwner.Dispose();
+            NextElement?.Dispose();
+        }
+
+        public byte[] ToArray() => ToArray(0, GetLastSegment().Length);
+        public byte[] ToArray(long start) => ToArray(start, GetLastSegment().Length - start);
+        public byte[] ToArray(long start, long length)
+        {
+            var dstOffset = 0;
+            var data = new byte[length];
+            var element = this;
+            while (element is not null)
+            {
+                if (element.RunningIndex < start)
+                {
+                    if (element.Length > start)
+                    {
+                        dstOffset += element.CopyTo(data, dstOffset, (int)(start - element.RunningIndex));
+                    }
+                }
+                else
+                {
+                    dstOffset += element.CopyTo(data, dstOffset);
+                }
+                element = element.NextElement;
+            }
+            return data;
+        }
+
+        private int CopyTo(byte[] data, int dstOffset) => CopyTo(data, dstOffset, 0);
+        private int CopyTo(byte[] data, int dstOffset, int start)
+        {
+            var mem = MemoryOwner.Memory.Slice(start);
+            mem.Span.CopyTo(new Span<byte>(data, dstOffset, mem.Length));
+            return mem.Length;
+        }
+        internal DataSegment GetLastSegment() => NextElement?.GetLastSegment() ?? this;
+
+        private class NotOwnedOwner : IMemoryOwner<byte>
+        {
+            public NotOwnedOwner(Memory<byte> data) => Memory = data;
+
+            public Memory<byte> Memory { get; }
+
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/UETools.Core/Interfaces/IUnrealValueReader.cs
+++ b/src/UETools.Core/Interfaces/IUnrealValueReader.cs
@@ -29,17 +29,6 @@ namespace UETools.Core.Interfaces
         /// <summary>
         /// Reads <see cref="Memory{T}"/> of bytes out of the underlying data stream.
         /// </summary>
-        /// <returns>Deserialized <see cref="Memory{T}"/> of bytes.</returns>
-        Memory<byte> GetBuffer();
-        /// <summary>
-        /// Reads <see cref="Span{T}"/> of bytes out of the underlying data stream.
-        /// </summary>
-        /// <returns>Deserialized <see cref="Span{T}"/> of bytes.</returns>
-        Span<byte> GetSpanBuffer();
-
-        /// <summary>
-        /// Reads <see cref="Memory{T}"/> of bytes out of the underlying data stream.
-        /// </summary>
         /// <param name="count">Number of bytes to read.</param>
         /// <returns>Deserialized <see cref="Memory{T}"/> of bytes.</returns>
         Memory<byte> ReadBytes(int count);
@@ -89,6 +78,20 @@ namespace UETools.Core.Interfaces
         /// </summary>
         /// <returns>Deserialized <see langword="uint"/> value.</returns>
         uint ReadUInt32();
+        /// <summary>
+        /// Get reader starting at specific <paramref name="start"/> offset.
+        /// </summary>
+        /// <param name="start">Offset at which the stream should start from the original stream.</param>
+        /// <returns>Reader of the selected part of the stream.</returns>
+        IUnrealValueReader Slice(long start);
+        /// <summary>
+        /// Get reader starting at specific <paramref name="start"/> offset, with specified <paramref name="length"/>.
+        /// </summary>
+        /// <param name="start">Offset at which the stream should start from the original stream.</param>
+        /// <param name="length">Length of the sliced stream from the original stream.</param>
+        /// <returns>Reader of the selected part of the stream.</returns>
+        IUnrealValueReader Slice(long start, long length);
+
         /// <summary>
         /// Reads <see langword="ulong"/> value out of the underlying data stream.
         /// </summary>

--- a/src/UETools.Pak/AesPakCryptoProvider.cs
+++ b/src/UETools.Pak/AesPakCryptoProvider.cs
@@ -28,41 +28,6 @@ namespace UETools.Pak
             _encryptor = _aesProvider.CreateEncryptor();
         }
 
-        public void DecryptEntry(Memory<byte> buffer, PakEntry entry)
-        {
-            if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))
-            {
-                DecryptEntry(segment.Array!, segment.Offset, segment.Count, entry);
-            }
-            else
-            {
-                var pool = ArrayPool<byte>.Shared.Rent(buffer.Length);
-                buffer.CopyTo(pool);
-                DecryptEntry(pool, 0, buffer.Length, entry);
-                pool.CopyTo(buffer);
-                ArrayPool<byte>.Shared.Return(pool);
-            }
-        }
-        public void DecryptEntry(byte[] array, int offset, int count, PakEntry entry)
-        {
-            if (entry.IsEncrypted)
-            {
-                var cnt = Math.Min(count, (int)entry.Size);
-                // Aes implementation doesn't need TransformFinalBlock, where it actually allocates array to return
-                var blockSize = _decryptor.InputBlockSize;
-                while (count > 0)
-                {
-                    var read = _decryptor.TransformBlock(array, offset, Math.Min(blockSize, cnt), array, offset);
-                    cnt -= read;
-                    offset += read;
-                }
-            }
-            count -= (int)entry.Size;
-            if (entry.LinkedEntry is PakEntry linked)
-            {
-                DecryptEntry(array, offset, count, entry);
-            }
-        }
         public void Decrypt(Memory<byte> buffer)
         {
             if (MemoryMarshal.TryGetArray<byte>(buffer, out var segment))

--- a/src/UETools.Pak/PakEntry.cs
+++ b/src/UETools.Pak/PakEntry.cs
@@ -90,42 +90,21 @@ namespace UETools.Pak
         }
 
         public FArchive Read() => new FArchive(Owner.ReadEntry(this));
-        public IMemoryOwner<byte> ReadBytes() => Owner.ReadEntry(this);
+        public DataSegment ReadBytes() => Owner.ReadEntry(this);
         public async ValueTask<FArchive> ReadAsync(CancellationToken cancellationToken = default) => new FArchive(await Owner.ReadEntryAsync(this, cancellationToken).ConfigureAwait(false));
 
         internal IMemoryOwner<byte> Read(Stream source)
         {
-            var mem = PakMemoryPool.Shared.Rent((int)TotalSize);
-            Read(source, mem.Memory);
+            var mem = PakMemoryPool.Shared.Rent((int)Size);
+            source.ReadWholeBuf(Offset + EntryHeaderSize, mem.Memory);
             return mem;
         }
         internal async ValueTask<IMemoryOwner<byte>> ReadAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            var mem = PakMemoryPool.Shared.Rent((int)TotalSize);
-            await ReadAsync(source, mem.Memory, cancellationToken).ConfigureAwait(false);
+            var mem = PakMemoryPool.Shared.Rent((int)Size);
+            await source.ReadWholeBufAsync(Offset + EntryHeaderSize, mem.Memory, cancellationToken).ConfigureAwait(false);
             return mem;
         }
-
-        private void Read(Stream source, Memory<byte> destination)
-        {
-            var size = (int)_size;
-            source.ReadWholeBuf(Offset + EntryHeaderSize, destination.Span.Slice(0, size));
-            LinkedEntry?.Read(source, destination.Slice(size));
-        }
-        private async ValueTask ReadAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default)
-        {
-            var size = (int)_size;
-            await source.ReadWholeBufAsync(Offset + EntryHeaderSize, destination.Slice(0, size), cancellationToken).ConfigureAwait(false);
-            if (LinkedEntry is null)
-                return;
-
-            await LinkedEntry.ReadAsync(source, destination.Slice(size), cancellationToken).ConfigureAwait(false);
-        }
-
-        internal long TotalSize => LinkedEntry is null ? _size : _size + LinkedEntry.TotalSize;
-        internal long TotalUncompressedSize => LinkedEntry is null ? _uncompressedSize : _uncompressedSize + LinkedEntry.TotalUncompressedSize;
-        internal bool IsAnyCompressed => LinkedEntry is null ? IsCompressed : IsCompressed || LinkedEntry.IsAnyCompressed;
-        internal bool IsAnyEncrypted => LinkedEntry is null ? IsEncrypted : IsEncrypted || LinkedEntry.IsAnyEncrypted;
 
         private long _offset;
         private long _size;

--- a/src/UETools.Pak/PakFile.cs
+++ b/src/UETools.Pak/PakFile.cs
@@ -39,43 +39,51 @@ namespace UETools.Pak
             _versionProvider = versionProvider ?? AutomaticVersionProvider.Instance;
         }
 
-        public IMemoryOwner<byte> ReadEntry(PakEntry entry)
+        private IMemoryOwner<byte> ProcessEntry(PakEntry entry)
         {
-            var buf = entry.Read(SourceStream);
-            if (entry.IsAnyEncrypted)
+            var data = entry.Read(SourceStream);
+            if (entry.IsEncrypted)
             {
                 if (_aesProvider is null)
                     throw new PakEncryptedException("Pak file contains encrypted entries. AES encryption key is necessary for reading this asset.");
 
-                _aesProvider.DecryptEntry(buf.Memory, entry);
+                // decrypts data inplace
+                _aesProvider.DecryptEntry(data.Memory, entry);
             }
-            if (entry.IsAnyCompressed)
-            {
-                var decompressed = UnrealCompression.Decompress(buf.Memory, entry);
-                buf.Dispose();
-                return decompressed;
-            }
-            else
-                return buf;
+            return entry.IsCompressed ? UnrealCompression.Decompress(data, entry) : data;
         }
-        public async ValueTask<IMemoryOwner<byte>> ReadEntryAsync(PakEntry entry, CancellationToken cancellationToken = default)
+        private async ValueTask<IMemoryOwner<byte>> ProcessEntryAsync(PakEntry entry, CancellationToken cancellationToken = default)
         {
-            var buf = await entry.ReadAsync(SourceStream, cancellationToken).ConfigureAwait(false);
-            if (entry.IsAnyEncrypted)
+            var data = await entry.ReadAsync(SourceStream, cancellationToken);
+            if (entry.IsEncrypted)
             {
                 if (_aesProvider is null)
                     throw new PakEncryptedException("Pak file contains encrypted entries. AES encryption key is necessary for reading this asset.");
 
-                _aesProvider.DecryptEntry(buf.Memory, entry);
+                _aesProvider.DecryptEntry(data.Memory, entry);
             }
-            if (entry.IsAnyCompressed)
+            return entry.IsCompressed ? await UnrealCompression.DecompressAsync(data, entry) : data;
+        }
+
+        public DataSegment ReadEntry(PakEntry entry)
+        {
+            var firstSegment = new DataSegment(ProcessEntry(entry));
+            var segments = firstSegment;
+            for (var ent = entry.LinkedEntry; ent is not null; ent = ent.LinkedEntry)
             {
-                var result = await UnrealCompression.DecompressAsync(buf.Memory, entry, cancellationToken).ConfigureAwait(false);
-                buf.Dispose();
-                return result;
+                segments = segments.Append(ProcessEntry(ent));
             }
-            else
-                return buf;
+            return firstSegment;
+        }
+        public async ValueTask<DataSegment> ReadEntryAsync(PakEntry entry, CancellationToken cancellationToken = default)
+        {
+            var firstSegment = new DataSegment(await ProcessEntryAsync(entry).ConfigureAwait(false));
+            var segments = firstSegment;
+            for (var ent = entry.LinkedEntry; ent is not null; ent = ent.LinkedEntry)
+            {
+                segments = segments.Append(await ProcessEntryAsync(ent).ConfigureAwait(false));
+            }
+            return firstSegment;
         }
 
         private static bool ReadPakInfo(Stream stream, long size, AesPakCryptoProvider? _aesProvider, [NotNullWhen(true)] out PakInfo? info)
@@ -86,7 +94,7 @@ namespace UETools.Pak
             {
                 var maxSize = values.Max();
                 using var data = PakMemoryPool.Shared.Rent(maxSize);
-                stream.ReadWholeBuf(-maxSize, SeekOrigin.End, data.Memory.Span);
+                stream.ReadWholeBuf(-maxSize, SeekOrigin.End, data.Memory);
                 foreach (var value in values)
                 {
                     if (value > size)
@@ -138,12 +146,10 @@ namespace UETools.Pak
                     if (AbsoluteIndex.TryGetValue(expPath, out var exports))
                     {
                         val.LinkedEntry = exports;
-                        exports.CompressionBlocks.OffsetBy(-(int)(val.Size));
                         var bulkPath = Path.ChangeExtension(kv.Key, ".ubulk");
                         if (AbsoluteIndex.TryGetValue(bulkPath, out var bulk))
                         {
                             exports.LinkedEntry = bulk;
-                            bulk.CompressionBlocks.OffsetBy(-(int)(exports.Size + val.Size));
                         }
                     }
                 }
@@ -185,19 +191,6 @@ namespace UETools.Pak
             }
 
             return null;
-        }
-
-        private IMemoryOwner<byte> ReadStream(long offset, long size)
-        {
-            var data = PakMemoryPool.Shared.Rent((int)size);
-            SourceStream.ReadWholeBuf(offset, data.Memory.Span);
-            return data;
-        }
-        private async ValueTask<IMemoryOwner<byte>> ReadStreamAsync(long offset, long size, CancellationToken cancellationToken)
-        {
-            var data = PakMemoryPool.Shared.Rent((int)size);
-            await SourceStream.ReadWholeBufAsync(offset, data.Memory, cancellationToken).ConfigureAwait(false);
-            return data;
         }
 
         public void Dispose() => SourceStream.Dispose();

--- a/src/UETools.Pak/PakFile.cs
+++ b/src/UETools.Pak/PakFile.cs
@@ -48,7 +48,7 @@ namespace UETools.Pak
                     throw new PakEncryptedException("Pak file contains encrypted entries. AES encryption key is necessary for reading this asset.");
 
                 // decrypts data inplace
-                _aesProvider.DecryptEntry(data.Memory, entry);
+                _aesProvider.Decrypt(data.Memory);
             }
             return entry.IsCompressed ? UnrealCompression.Decompress(data, entry) : data;
         }
@@ -60,7 +60,7 @@ namespace UETools.Pak
                 if (_aesProvider is null)
                     throw new PakEncryptedException("Pak file contains encrypted entries. AES encryption key is necessary for reading this asset.");
 
-                _aesProvider.DecryptEntry(data.Memory, entry);
+                _aesProvider.Decrypt(data.Memory);
             }
             return entry.IsCompressed ? await UnrealCompression.DecompressAsync(data, entry) : data;
         }

--- a/src/UETools.Pak/UnrealCompression.cs
+++ b/src/UETools.Pak/UnrealCompression.cs
@@ -15,9 +15,14 @@ namespace UETools.Pak
 {
     internal class UnrealCompression
     {
+        public static IMemoryOwner<byte> Decompress(IMemoryOwner<byte> compressedData, PakEntry entry)
+        {
+            using var data = compressedData;
+            return Decompress(data.Memory, entry);
+        }
         public static IMemoryOwner<byte> Decompress(Memory<byte> compressed, PakEntry entry)
         {
-            var decompressed = PakMemoryPool.Shared.Rent((int)entry.TotalUncompressedSize);
+            var decompressed = PakMemoryPool.Shared.Rent((int)entry.UncompressedSize);
             if (MemoryMarshal.TryGetArray<byte>(compressed, out var src) && MemoryMarshal.TryGetArray<byte>(decompressed.Memory, out var dst))
                 Decompress(src.Array!, src.Offset, src.Count, dst.Array!, dst.Offset, dst.Count, entry);
             else
@@ -36,41 +41,27 @@ namespace UETools.Pak
         }
         private static void DecompressEntry(MemoryStream mem, byte[] destination, int dstOffset, int dstCount, PakEntry entry, int progress = 0)
         {
-            if (entry.IsCompressed is false)
+            foreach (var block in entry.CompressionBlocks)
             {
-                var size = (int)entry.Size;
-                mem.ReadCount(destination, dstOffset + progress, dstCount - progress, size);
-                progress += size;
-            }
-            else
-            {
-                foreach (var block in entry.CompressionBlocks)
+                mem.Seek(block.Start, SeekOrigin.Begin);
+                using var stream = GetDecompressStream(mem, entry.CompressionMethod);
+                var read = 0;
+                do
                 {
-                    mem.Seek(block.Start, SeekOrigin.Begin);
-                    using Stream stream = entry.CompressionMethod switch
-                    {
-                        1 => new Ionic.Zlib.ZlibStream(mem, Ionic.Zlib.CompressionMode.Decompress, true),
-                        2 => new GZipStream(mem, CompressionMode.Decompress, true),
-                        _ => throw new NotImplementedException($"CompressionMethod '{entry.CompressionMethod}' not implemented")
-                    };
-                    var read = 0;
-                    do
-                    {
-                        read = stream.Read(destination, dstOffset + progress, dstCount - progress);
-                        progress += read;
-                    } while (read > 0);
-                    mem.Seek(block.End, SeekOrigin.Begin);
-                }
-            }
-            if(entry.LinkedEntry is PakEntry linked)
-            {
-                DecompressEntry(mem, destination, dstOffset, dstCount, linked, progress);
+                    read = stream.Read(destination, dstOffset + progress, dstCount - progress);
+                    progress += read;
+                } while (read > 0);
             }
         }
 
+        public static async ValueTask<IMemoryOwner<byte>> DecompressAsync(IMemoryOwner<byte> compressedData, PakEntry entry)
+        {
+            using var data = compressedData;
+            return await DecompressAsync(data.Memory, entry);
+        }
         public static async ValueTask<IMemoryOwner<byte>> DecompressAsync(Memory<byte> compressed, PakEntry entry, CancellationToken cancellationToken = default)
         {
-            var decompressed = PakMemoryPool.Shared.Rent((int)entry.TotalUncompressedSize);
+            var decompressed = PakMemoryPool.Shared.Rent((int)entry.UncompressedSize);
             if (MemoryMarshal.TryGetArray<byte>(compressed, out var src) && MemoryMarshal.TryGetArray<byte>(decompressed.Memory, out var dst))
             {
                 await DecompressAsync(src.Array!, src.Offset, src.Count, dst.Array!, dst.Offset, dst.Count, entry, cancellationToken).ConfigureAwait(false);
@@ -89,35 +80,24 @@ namespace UETools.Pak
         }
         private static async ValueTask DecompressEntryAsync(MemoryStream mem, byte[] destination, int dstOffset, int dstCount, PakEntry entry, int progress = 0, CancellationToken cancellationToken = default)
         {
-            if (entry.IsCompressed is false)
+            foreach (var block in entry.CompressionBlocks)
             {
-                var size = (int)entry.Size;
-                await mem.ReadCountAsync(destination, dstOffset + progress, dstCount - progress, size, cancellationToken).ConfigureAwait(false);
-                progress = size;
-            }
-            else
-            {
-                foreach (var block in entry.CompressionBlocks)
+                mem.Seek(block.Start, SeekOrigin.Begin);
+                using var stream = GetDecompressStream(mem, entry.CompressionMethod);
+                var read = 0;
+                do
                 {
-                    mem.Seek(block.Start, SeekOrigin.Begin);
-                    using Stream stream = entry.CompressionMethod switch
-                    {
-                        1 => new Ionic.Zlib.ZlibStream(mem, Ionic.Zlib.CompressionMode.Decompress, true),
-                        2 => new GZipStream(mem, CompressionMode.Decompress, true),
-                        _ => throw new NotImplementedException($"CompressionMethod '{entry.CompressionMethod}' not implemented")
-                    };
-                    var read = 0;
-                    do
-                    {
-                        read = await stream.ReadAsync(destination, dstOffset + progress, dstCount - progress, cancellationToken).ConfigureAwait(false);
-                        progress += read;
-                    } while (read > 0);
-                }
-            }
-            if (entry.LinkedEntry is PakEntry linked)
-            {
-                await DecompressEntryAsync(mem, destination, dstOffset, dstCount, linked, progress).ConfigureAwait(false);
+                    read = await stream.ReadAsync(destination, dstOffset + progress, dstCount - progress, cancellationToken).ConfigureAwait(false);
+                    progress += read;
+                } while (read > 0);
             }
         }
+
+        internal static Stream GetDecompressStream(MemoryStream mem, int compressionMethod) => compressionMethod switch
+        {
+            1 => new Ionic.Zlib.ZlibStream(mem, Ionic.Zlib.CompressionMode.Decompress, true),
+            2 => new GZipStream(mem, CompressionMode.Decompress, true),
+            _ => throw new NotImplementedException($"CompressionMethod '{compressionMethod}' not implemented")
+        };
     }
 }


### PR DESCRIPTION
Treating separate segments of file as separate memory chunks simplifies logic for unpacking, encrypting and PakEntry class itself.